### PR TITLE
feat: added function for returning available nameservers

### DIFF
--- a/api.go
+++ b/api.go
@@ -54,6 +54,23 @@ func (c Apiaccess) availablettl() (*resty.Response, error) {
 	return apireq(path, c)
 }
 
+type nslist struct {
+	Authid       int    `json:"auth-id,omitempty"`
+	Subauthid    int    `json:"sub-auth-id,omitempty"`
+	Authpassword string `json:"auth-password"`
+	DetailedInfo int    `json:"detailed-info,ommitempty"`
+}
+
+func (n nslist) lsns() (*resty.Response, error) {
+	const path = "/dns/available-name-servers.json"
+	return apireq(path, n)
+}
+
+type retns struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
 type rectypes struct {
 	Authid       int    `json:"auth-id,omitempty"`
 	Subauthid    int    `json:"sub-auth-id,omitempty"`


### PR DESCRIPTION
I was running into an annoying issue with DK domains, in that the administrator for .dk domains (punktum.dk) doesn't allow for more then seven authoritative NS servers, and the default for ClouDNS is to register eight (four free and four premium NS servers) leaving it necessary to remove one of the NS servers after creating the zone.
To make matters worse they (punktum.dk) didn't recognize two of the remaining NS serveres, meaning only five got registered... \*sigh\*

Long story sh... Long; I wanted to update the ClouDNS terraform provider to be able to handle this, but in order to do so it's required to identify the NS servers available to the account, hence I've made this suggested addition to this repository.
This will enable the provider to fetch all available NS servers, and then my intention was that it would either 1) make it optional whether to use "all", "free" or "premium" NS servers when creating a zone (defaulting to "all",) or 2) make it optional to pass an array of NS server names when creating a zone.

I've yet to decide on the approach, I might actually end up writing something which supports both. But this change will enable the updates in the terraform provider, hence I'm starting here.